### PR TITLE
Add show_festivizer when importing item

### DIFF
--- a/src/client/ts/loadout/serializer.ts
+++ b/src/client/ts/loadout/serializer.ts
@@ -215,6 +215,11 @@ async function importItem2(context: ImportContext, item: Item, itemJSON: itemJSO
 		item.setSheen(sheenId);
 	}
 
+	const showFestivizer = itemJSON.show_festivizer;
+	if (showFestivizer !== undefined) {
+		item.showFestivizer(showFestivizer);
+	}
+
 	item.setKillCount(itemJSON.kill_count ?? itemJSON.killCount ?? null);
 
 	item.setWeaponEffectId(itemJSON.weapon_effect_id ?? itemJSON.weaponEffectId ?? null);


### PR DESCRIPTION
I noticed when loading a preset via @jsonloadout, the festivizer is not showing.
I added `show_festivizer` to the serializer when importing an item.

test with

```json
{"characters":[{"npc":"warpaints","items":[{"id":"996","warpaint_id":303,"warpaint_seed":"12252674370435881800","weapon_effect_id":702,"show_festivizer":true}]}]}
```

```json
{"characters":[{"npc":"demoman","items":[{"id":"207~0","show_festivizer":true}]}]}
```